### PR TITLE
Add stats page with puzzle and player metrics

### DIFF
--- a/src/app/api/stats/route.ts
+++ b/src/app/api/stats/route.ts
@@ -1,0 +1,39 @@
+import { NextResponse } from 'next/server'
+import { prisma } from '@/lib/prisma'
+
+function getTodayDate(): string {
+  const now = new Date()
+  const adjustedNow = new Date(now.getTime() + 14 * 60 * 60 * 1000)
+  return adjustedNow.toISOString().split('T')[0]
+}
+
+export async function GET() {
+  try {
+    const today = getTodayDate()
+
+    const allLevels = await prisma.level.findMany({
+      orderBy: { date: 'asc' },
+      select: {
+        date: true,
+        _count: { select: { submissions: true } },
+      },
+    })
+
+    const pastLevels = allLevels.filter((l) => l.date <= today)
+    const futureLevels = allLevels.filter((l) => l.date > today)
+
+    const days = pastLevels.map((l) => ({
+      date: l.date,
+      players: l._count.submissions,
+    }))
+
+    const futurePuzzleCount = futureLevels.length
+    const lastFutureDate =
+      futureLevels.length > 0 ? futureLevels[futureLevels.length - 1].date : null
+
+    return NextResponse.json({ days, futurePuzzleCount, lastFutureDate })
+  } catch (error) {
+    console.error('Error fetching stats:', error)
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}

--- a/src/app/stats/page.tsx
+++ b/src/app/stats/page.tsx
@@ -1,0 +1,121 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+import { Header } from '@/components/ui/Header'
+import { Card } from '@/components/ui/Card'
+
+interface DayStats {
+  date: string
+  players: number
+}
+
+interface StatsData {
+  days: DayStats[]
+  futurePuzzleCount: number
+  lastFutureDate: string | null
+}
+
+function formatDate(dateStr: string): string {
+  const d = new Date(dateStr + 'T00:00:00')
+  return d.toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric', year: 'numeric' })
+}
+
+export default function StatsPage() {
+  const [stats, setStats] = useState<StatsData | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    fetch('/api/stats')
+      .then((res) => {
+        if (!res.ok) throw new Error('Failed to load stats')
+        return res.json()
+      })
+      .then((data) => {
+        setStats(data)
+      })
+      .catch((err) => {
+        setError(err.message)
+      })
+      .finally(() => setLoading(false))
+  }, [])
+
+  const reversedDays = stats ? [...stats.days].reverse() : []
+
+  return (
+    <div className="min-h-screen flex flex-col">
+      <Header />
+
+      <main className="flex-1 p-6">
+        <div className="max-w-2xl mx-auto">
+          <h1 className="text-3xl font-bold mb-8">Stats</h1>
+
+          {loading && (
+            <div className="text-center text-gray-400 py-12">Loading...</div>
+          )}
+
+          {error && (
+            <Card className="text-center py-8">
+              <p className="text-red-400">{error}</p>
+            </Card>
+          )}
+
+          {stats && (
+            <>
+              <Card className="mb-6">
+                <div className="flex flex-col sm:flex-row sm:gap-12 gap-4">
+                  <div>
+                    <div className="text-sm text-gray-400 mb-1">Total puzzles published</div>
+                    <div className="text-2xl font-bold text-emerald-400">{stats.days.length}</div>
+                  </div>
+                  <div>
+                    <div className="text-sm text-gray-400 mb-1">Future puzzles</div>
+                    <div className="text-2xl font-bold text-emerald-400">{stats.futurePuzzleCount}</div>
+                    {stats.lastFutureDate && (
+                      <div className="text-xs text-gray-500 mt-0.5">through {formatDate(stats.lastFutureDate)}</div>
+                    )}
+                  </div>
+                  <div>
+                    <div className="text-sm text-gray-400 mb-1">Total players (all time)</div>
+                    <div className="text-2xl font-bold text-emerald-400">
+                      {stats.days.reduce((sum, d) => sum + d.players, 0).toLocaleString()}
+                    </div>
+                  </div>
+                </div>
+              </Card>
+
+              <Card>
+                <table className="w-full text-sm">
+                  <thead>
+                    <tr className="text-left text-gray-400 border-b border-gray-700">
+                      <th className="pb-3 pr-4 font-medium">Date</th>
+                      <th className="pb-3 font-medium text-right">Players</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {reversedDays.length === 0 ? (
+                      <tr>
+                        <td colSpan={2} className="py-8 text-center text-gray-500">
+                          No data yet.
+                        </td>
+                      </tr>
+                    ) : (
+                      reversedDays.map((day) => (
+                        <tr key={day.date} className="border-b border-gray-800 last:border-0">
+                          <td className="py-2.5 pr-4 text-gray-300">{formatDate(day.date)}</td>
+                          <td className="py-2.5 text-right font-mono text-emerald-400">
+                            {day.players.toLocaleString()}
+                          </td>
+                        </tr>
+                      ))
+                    )}
+                  </tbody>
+                </table>
+              </Card>
+            </>
+          )}
+        </div>
+      </main>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
This PR adds a new stats page that displays puzzle publication metrics and player engagement data. It includes both a frontend page and a backend API endpoint to fetch and display statistics.

## Key Changes
- **New Stats Page** (`src/app/stats/page.tsx`): A client-side React component that displays:
  - Total puzzles published (past puzzles only)
  - Future puzzles count with the latest scheduled date
  - Total all-time player count across all puzzles
  - A detailed table showing player counts per puzzle date, sorted in reverse chronological order

- **New Stats API Endpoint** (`src/app/api/stats/route.ts`): A GET endpoint that:
  - Fetches all levels from the database with submission counts
  - Separates past and future puzzles using a timezone-adjusted "today" date (UTC+14)
  - Returns aggregated statistics including per-day player counts and future puzzle information

## Implementation Details
- The stats page uses a custom `getTodayDate()` function that adjusts for UTC+14 timezone to properly categorize puzzles as past or future
- Player count is derived from the submission count for each level
- The UI displays loading and error states with appropriate messaging
- Dates are formatted consistently using `formatDate()` helper with locale-aware formatting
- The table displays dates in reverse chronological order (newest first) for better UX
- All numeric values are formatted with locale-specific thousand separators

https://claude.ai/code/session_01Dn4faUPJerNus82niW5UsR